### PR TITLE
Fixed issues in the spacy component

### DIFF
--- a/spacy_component.py
+++ b/spacy_component.py
@@ -1,10 +1,8 @@
-import re
-from typing import List
 
 from spacy import Language, util
 from spacy.tokens import Doc, Span
 from transformers import pipeline
-
+from typing import List
 
 def extract_triplets(text: str) -> List[str]:
     """
@@ -18,68 +16,110 @@ def extract_triplets(text: str) -> List[str]:
     :type text: str
     :return: A list of dictionaries.
     """
+
     triplets = []
     relation, subject, relation, object_ = "", "", "", ""
     text = text.strip()
     current = "x"
+
     for token in text.replace("<s>", "").replace("<pad>", "").replace("</s>", "").split():
-        if token == "<triplet>":
+
+        if (token == "<triplet>"):
+
             current = "t"
-            if relation != "":
+
+            if (relation != ""):
+
                 triplets.append(
-                    {"head": subject.strip(), "type": relation.strip(), "tail": object_.strip()}
-                )
+                        {
+                            "head": subject.strip(),
+                            "type": relation.strip(),
+                            "tail": object_.strip()
+                            }
+                        )
                 relation = ""
+
             subject = ""
-        elif token == "<subj>":
+
+        elif (token == "<subj>"):
+
             current = "s"
-            if relation != "":
+
+            if (relation != ""):
+
                 triplets.append(
-                    {"head": subject.strip(), "type": relation.strip(), "tail": object_.strip()}
-                )
+                    {
+                        "head": subject.strip(),
+                        "type": relation.strip(),
+                        "tail": object_.strip()
+                        }
+                    )
+
             object_ = ""
-        elif token == "<obj>":
+
+        elif (token == "<obj>"):
+
             current = "o"
             relation = ""
+
         else:
-            if current == "t":
+
+            if (current == "t"):
+
                 subject += " " + token
-            elif current == "s":
+
+            elif (current == "s"):
+
                 object_ += " " + token
-            elif current == "o":
+
+            elif (current == "o"):
+
                 relation += " " + token
-    if subject != "" and relation != "" and object_ != "":
+
+    if ((subject != "") and (relation != "") and (object_ != "")):
+
         triplets.append(
-            {"head": subject.strip(), "type": relation.strip(), "tail": object_.strip()}
-        )
+                {
+                    "head": subject.strip(),
+                    "type": relation.strip(),
+                    "tail": object_.strip()
+                    }
+                )
 
     return triplets
 
 
 @Language.factory(
-    "rebel",
-    requires=["doc.sents"],
-    assigns=["doc._.rel"],
-    default_config={
-        "model_name": "Babelscape/rebel-large",
-        "device": 0,
-    },
-)
-class RebelComponent:
-    def __init__(
-        self,
-        nlp,
-        name,
-        model_name: str,
-        device: int,
-    ):
-        assert model_name is not None, ""
-        self.triplet_extractor = pipeline(
-            "text2text-generation", model=model_name, tokenizer=model_name, device=device
+        "rebel",
+        requires = ["doc.sents"],
+        assigns = ["doc._.rel"],
+        default_config = {
+            "model_name": "Babelscape/rebel-large",
+            "device": 0,
+            },
         )
+class RebelComponent:
+
+    def __init__(
+            self,
+            nlp, name,
+            model_name: str,
+            device: int,
+        ):
+
+        assert model_name is not None, ""
+
+        self.triplet_extractor = pipeline(
+                "text2text-generation",
+                model = model_name,
+                tokenizer = model_name,
+                device = device
+                )
+
         # Register custom extension on the Doc
-        if not Doc.has_extension("rel"):
-            Doc.set_extension("rel", default={})
+        if (not Doc.has_extension("rel")):
+
+            Doc.set_extension("rel", default = {})
 
     def _generate_triplets(self, sents: List[Span]) -> List[List[dict]]:
         """
@@ -103,15 +143,21 @@ class RebelComponent:
         :type sents: List[Span]
         :return: A list of lists of dicts.
         """
+
         output_ids = self.triplet_extractor(
-            [sent.text for sent in sents], return_tensors=True, return_text=False
-        )  # [0]["generated_token_ids"]
+                [sent.text for sent in sents],
+                return_tensors = True,
+                return_text = False
+                )  # [0]["generated_token_ids"]
         extracted_texts = self.triplet_extractor.tokenizer.batch_decode(
             [out["generated_token_ids"] for out in output_ids]
-        )
+            )
         extracted_triplets = []
+
         for text in extracted_texts:
+
             extracted_triplets.extend(extract_triplets(text))
+
         return extracted_triplets
 
     def set_annotations(self, doc: Doc, triplets: List[dict]):
@@ -126,26 +172,40 @@ class RebelComponent:
         :param triplets: List[dict]
         :type triplets: List[dict]
         """
+
+        text = doc.text.lower()
+
         for triplet in triplets:
-            # get substring to spacy span
-            head_span = re.search(triplet["head"], doc.text)
-            tail_span = re.search(triplet["tail"], doc.text)
-            # get spacy span
-            if head_span is not None:
-                head_span = doc.char_span(head_span.start(), head_span.end())
-            else:
-                head_span = triplet["head"]
-            if tail_span is not None:
-                tail_span = doc.char_span(tail_span.start(), tail_span.end())
-            else:
-                tail_span = triplet["tail"]
-            offset = (head_span.start, tail_span.start)
-            if offset not in doc._.rel:
+
+            if (triplet["head"] == triplet["tail"]):
+
+                continue
+
+            head_index = doc.text.lower().find(triplet["head"].lower())
+            tail_index = doc.text.lower().find(triplet["tail"].lower())
+
+            if ((head_index == -1) or (tail_index == -1)):
+
+                continue
+
+            head_span = doc.char_span(head_index, head_index + len(triplet["head"]), alignment_mode = "expand")
+            tail_span = doc.char_span(tail_index, tail_index + len(triplet["tail"]), alignment_mode = "expand")
+
+            try:
+
+                offset = (head_span.start, tail_span.start)
+
+            except (AttributeError):
+
+                continue
+
+            if (offset not in doc._.rel):
+
                 doc._.rel[offset] = {
-                    "relation": triplet["type"],
-                    "head_span": head_span,
-                    "tail_span": tail_span,
-                }
+                        "relation": triplet["type"],
+                        "head_span": head_span,
+                        "tail_span": tail_span,
+                        }
 
     def __call__(self, doc: Doc) -> Doc:
         """
@@ -155,11 +215,13 @@ class RebelComponent:
         :type doc: Doc
         :return: A Doc object with the sentence triplets added as annotations.
         """
+
         sentence_triplets = self._generate_triplets(doc.sents)
         self.set_annotations(doc, sentence_triplets)
+
         return doc
 
-    def pipe(self, stream, batch_size=128):
+    def pipe(self, stream, batch_size = 128):
         """
         It takes a stream of documents, and for each document,
         it generates a list of sentence triplets,
@@ -168,14 +230,23 @@ class RebelComponent:
         :param stream: a generator of Doc objects
         :param batch_size: The number of documents to process at a time, defaults to 128 (optional)
         """
+
         for docs in util.minibatch(stream, size=batch_size):
+
             sents = []
+
             for doc in docs:
+
                 sents += doc.sents
+
             sentence_triplets = self._generate_triplets(sents)
             index = 0
+
             for doc in docs:
+
                 n_sent = len(list(doc.sents))
                 self.set_annotations(doc, sentence_triplets[index : index + n_sent])
                 index += n_sent
+
                 yield doc
+

--- a/spacy_component.py
+++ b/spacy_component.py
@@ -181,8 +181,8 @@ class RebelComponent:
 
                 continue
 
-            head_index = doc.text.lower().find(triplet["head"].lower())
-            tail_index = doc.text.lower().find(triplet["tail"].lower())
+            head_index = text.find(triplet["head"].lower())
+            tail_index = text.find(triplet["tail"].lower())
 
             if ((head_index == -1) or (tail_index == -1)):
 


### PR DESCRIPTION
The spacy component can fail in a few ways.

* If the `head` or `tail` text contains special regex characters like "." the matching can be unpredictable. This was fixed by using `str.find` instead.
* sometimes the model will capitalize words in `head` or `tail`. Fixed by lower casing all text before searching.
* character encodes of different sizes can cause `doc.char_span` to return `None` in certain cases. Fixed by using `expand` for `alignment_mode` to minimize the problem and catching the cases where the span is still `None`.